### PR TITLE
Feat/automatic typing

### DIFF
--- a/humitifier-common/src/humitifier_common/artefacts/__init__.py
+++ b/humitifier-common/src/humitifier_common/artefacts/__init__.py
@@ -1,5 +1,4 @@
 from .generic import *
-from .desktop import *
 from .server import *
 from .special import *
 from .registry import registry

--- a/humitifier-common/src/humitifier_common/artefacts/desktop.py
+++ b/humitifier-common/src/humitifier_common/artefacts/desktop.py
@@ -1,3 +1,0 @@
-"""
-A collection of facts that only make sense to collect on a desktop.
-"""

--- a/humitifier-common/src/humitifier_common/artefacts/generic.py
+++ b/humitifier-common/src/humitifier_common/artefacts/generic.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+from humitifier_common.artefacts.groups import GENERIC
 from humitifier_common.artefacts.registry import fact, metric
 from humitifier_common.artefacts.registry.registry import ArtefactMetadata
 
@@ -30,7 +31,7 @@ class MemoryRange(BaseModel):
     block: str
 
 
-@fact(group="generic")
+@fact(group=GENERIC)
 class Hardware(BaseModel):
     num_cpus: int
     memory: list[MemoryRange]
@@ -53,7 +54,7 @@ class Block(BaseModel):
     mount: str
 
 
-@metric(group="generic")
+@metric(group=GENERIC)
 class Blocks(list[Block]):
     pass
 
@@ -69,7 +70,7 @@ class Group(BaseModel):
     users: list[str]
 
 
-@fact(group="generic")
+@fact(group=GENERIC)
 class Groups(list[Group]):
     pass
 
@@ -83,7 +84,7 @@ class User(BaseModel):
     shell: str
 
 
-@fact(group="generic")
+@fact(group=GENERIC)
 class Users(list[User]):
     pass
 
@@ -93,7 +94,7 @@ class Users(list[User]):
 ##
 
 
-@fact(group="generic")
+@fact(group=GENERIC)
 class HostnameCtl(BaseModel):
     hostname: str
     os: str
@@ -107,7 +108,7 @@ class HostnameCtl(BaseModel):
 ##
 
 
-@metric(group="generic")
+@metric(group=GENERIC)
 class Memory(BaseModel):
     total_mb: int
     used_mb: int
@@ -127,7 +128,7 @@ class Package(BaseModel):
     version: str
 
 
-@fact(group="generic")
+@fact(group=GENERIC)
 class PackageList(list[Package]):
     pass
 
@@ -152,6 +153,6 @@ class NetworkInterface(BaseModel):
     addresses: list[AddressInfo]
 
 
-@fact(group="generic", metadata=ArtefactMetadata(null_is_valid=True))
+@fact(group=GENERIC, metadata=ArtefactMetadata(null_is_valid=True))
 class NetworkInterfaces(list[NetworkInterface]):
     pass

--- a/humitifier-common/src/humitifier_common/artefacts/groups.py
+++ b/humitifier-common/src/humitifier_common/artefacts/groups.py
@@ -1,0 +1,3 @@
+GENERIC = "generic"
+SERVER = "server"
+SPECIAL = "special"

--- a/humitifier-common/src/humitifier_common/artefacts/registry/registry.py
+++ b/humitifier-common/src/humitifier_common/artefacts/registry/registry.py
@@ -6,6 +6,8 @@ Used by agent/server to retrieve the facts dynamically.
 from dataclasses import dataclass
 from enum import Enum
 
+from humitifier_common.utils.pydantic import insert_pydantic_schema_proxy
+
 
 ##
 ## Registry
@@ -330,6 +332,8 @@ def fact(
     """
 
     def decorator(fact_cls):
+        insert_pydantic_schema_proxy(fact_cls)
+
         actual_name = name or fact_cls.__name__
 
         registry.register(
@@ -367,6 +371,8 @@ def metric(
     """
 
     def decorator(metric_cls):
+        insert_pydantic_schema_proxy(metric_cls)
+
         actual_name = name or metric_cls.__name__
 
         registry.register(

--- a/humitifier-common/src/humitifier_common/artefacts/server.py
+++ b/humitifier-common/src/humitifier_common/artefacts/server.py
@@ -4,6 +4,7 @@ A collection of facts that only make sense to collect on a server.
 
 from pydantic import BaseModel
 
+from humitifier_common.artefacts.groups import SERVER
 from humitifier_common.artefacts.registry import fact, metric
 
 
@@ -18,7 +19,7 @@ class VHost(BaseModel):
     serveraliases: list[str] | None = None
 
 
-@fact(group="server")
+@fact(group=SERVER)
 class HostMeta(BaseModel):
     department: str | None = None
     contact: str | None = None
@@ -34,7 +35,7 @@ class HostMeta(BaseModel):
 ##
 
 
-@metric(group="server")
+@metric(group=SERVER)
 class Uptime(float):
     pass
 
@@ -44,7 +45,7 @@ class Uptime(float):
 ##
 
 
-@fact(group="server")
+@fact(group=SERVER)
 class PuppetAgent(BaseModel):
     enabled: bool
     running: bool | None
@@ -63,7 +64,7 @@ class PuppetAgent(BaseModel):
 ##
 
 
-@fact(group="server")
+@fact(group=SERVER)
 class IsWordpress(BaseModel):
     is_wp: bool
 
@@ -73,7 +74,7 @@ class IsWordpress(BaseModel):
 ##
 
 
-@fact(group="server")
+@fact(group=SERVER)
 class RebootPolicy(BaseModel):
     configured: bool
     enabled: bool | None = None

--- a/humitifier-common/src/humitifier_common/artefacts/special.py
+++ b/humitifier-common/src/humitifier_common/artefacts/special.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel
 
+from humitifier_common.artefacts.groups import SPECIAL
 from humitifier_common.artefacts.registry import metric
 
 ##
@@ -20,7 +21,7 @@ class ZFSPool(BaseModel):
     used_mb: int
 
 
-@metric(group="special")
+@metric(group=SPECIAL)
 class ZFS(BaseModel):
     pools: list[ZFSPool]
     volumes: list[ZFSVolume]

--- a/humitifier-common/src/humitifier_common/utils/pydantic.py
+++ b/humitifier-common/src/humitifier_common/utils/pydantic.py
@@ -1,0 +1,87 @@
+from typing import Any, Optional, Type, TypedDict, Callable
+from pydantic import BaseModel, GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+
+def create_typed_dict(typed_dict_name: str, registry_function, total: bool = False):
+    """
+    Creates a dynamically typed dictionary with specified attributes and fields.
+
+    Generates a custom TypedDict based on the provided typed dictionary name,
+    a function that registers and returns a sequence of artefacts, and a flag
+    indicating whether all fields should be total or optional. The fields
+    of the TypedDict are determined based on the attributes of the artefacts
+    returned by the registry function. Each field will represent a specific
+    artefact, either as Optional or required, depending on the total flag.
+
+    :param typed_dict_name: The name to assign to the dynamically created TypedDict.
+    :param registry_function: A callable function that returns a sequence of
+                              artefacts to be included as fields in the TypedDict.
+    :param total: A boolean flag indicating whether all fields in the
+                  TypedDict should be mandatory (total=True) or optional (total=False).
+    :return: A dynamically constructed TypedDict with the specified name and
+             fields derived from the registry function.
+    """
+    fields = {
+        artefact.__artefact_name__: Optional[artefact]
+        for artefact in registry_function()
+    }
+    return TypedDict(typed_dict_name, fields, total=total)
+
+
+def insert_pydantic_schema_proxy(wrapped_class):
+    """
+    Inserts a special proxy method '__get_pydantic_core_schema__' into a class that is not
+    a subclass of BaseModel. This ensures compatibility with Pydantic's schema generation
+    process by injecting a handler function to determine core schema from the appropriate
+    base class. If the wrapped class already contains this method, it does not overwrite it,
+    and no further action is taken.
+
+    Mainly, this is to solve cases like `class Artefact(list[SubType])`; pydantic
+    doesn't understand this is just a fancy list. The inserted method will pass
+    `list[SubType]` back as the type, which pydantic can understand.
+
+    :param wrapped_class: The class into which the proxy method is to be injected, if it
+        is not already a subclass of BaseModel.
+    :type wrapped_class: Type[Any]
+    :return: The original wrapped class, potentially with the new proxy method added.
+    :rtype: Type[Any]
+    :raises ValueError: If the class does not have valid base class(es), or if the class
+        has multiple base classes, rendering schema determination ambiguous.
+    """
+    if not issubclass(wrapped_class, BaseModel):
+
+        # Do nothing if the class already has a method set
+        if hasattr(wrapped_class, "__get_pydantic_core_schema__"):
+            return
+
+        @classmethod  # noqa; it's _fine_ linter
+        def __get_pydantic_core_schema__(
+            cls: Type[Any], source: Type[Any], handler: GetCoreSchemaHandler
+        ) -> core_schema.CoreSchema:
+            # Dunno why this is needed; everyone seems to want it
+            assert source is cls
+
+            # First, get __orig_bases__; this contians the full typing
+            bases = getattr(cls, "__orig_bases__", None)
+            # If somehow we don't have that, fall back to __bases__
+            if not bases:
+                bases = cls.__bases__
+
+            # Filter out `object`, as classes without a parent need to be caught.
+            bases = [base for base in bases if base is not object]
+            # If we don't have any bases (well, `object` is the base then, but okay)
+            # we need to stop here and now and tell the dev to implement pydantic
+            # compatibility
+            if not bases:
+                raise ValueError(
+                    f"Class {cls.__name__} does not have a valid base class. Please implement __get_pydantic_core_schema__"
+                )
+
+            # Assume the last specified base is the correct one
+            item_type = bases[-1]
+
+            return handler(item_type)
+
+        # Set our method
+        wrapped_class.__get_pydantic_core_schema__ = __get_pydantic_core_schema__


### PR DESCRIPTION
This pull request introduces several changes to improve the consistency and functionality of the `humitifier-common` package, particularly focusing on the `artefacts` module and related utilities. The most important changes include the removal of the desktop artefacts, the introduction of constants for group names, and the use of a utility to create typed dictionaries for artefacts.

### Removal of Desktop Artefacts:
* [`humitifier-common/src/humitifier_common/artefacts/__init__.py`](diffhunk://#diff-b204f00da934f6ce1986050629e716f2ee3ba680685e4910712ccb0938616a6cL2): Removed the import for `desktop` artefacts.
* [`humitifier-common/src/humitifier_common/artefacts/desktop.py`](diffhunk://#diff-90303462c7433394a8411e09ecf50918f9fb16a1a68171d67cb101a6735fbf16L1-L3): Removed the entire file, which contained facts specific to desktop environments.

### Introduction of Group Constants:
* [`humitifier-common/src/humitifier_common/artefacts/groups.py`](diffhunk://#diff-858eaddc13192f0d2164c70c77f5f0b3f36a4b2eda615569d8d08195b60d74d1R1-R3): Added constants `GENERIC`, `SERVER`, and `SPECIAL` for group names.
* Updated group references in various artefacts to use these constants instead of hardcoded strings:
  * `humitifier-common/src/humitifier_common/artefacts/generic.py` [[1]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL33-R34) [[2]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL56-R57) [[3]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL72-R73) [[4]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL86-R87) [[5]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL96-R97) [[6]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL110-R111) [[7]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL130-R131) [[8]](diffhunk://#diff-e3eb86b9beba609be1a2f92dd089a4b308cfe6e1f2ce0e7400a409cb76fa8bdfL155-R156)
  * `humitifier-common/src/humitifier_common/artefacts/server.py` [[1]](diffhunk://#diff-6aa716b07a39c4688b8e2f50fee72b504e7e61372e5e4f0c1196c3e74ce9184fL21-R22) [[2]](diffhunk://#diff-6aa716b07a39c4688b8e2f50fee72b504e7e61372e5e4f0c1196c3e74ce9184fL37-R38) [[3]](diffhunk://#diff-6aa716b07a39c4688b8e2f50fee72b504e7e61372e5e4f0c1196c3e74ce9184fL47-R48) [[4]](diffhunk://#diff-6aa716b07a39c4688b8e2f50fee72b504e7e61372e5e4f0c1196c3e74ce9184fL66-R67) [[5]](diffhunk://#diff-6aa716b07a39c4688b8e2f50fee72b504e7e61372e5e4f0c1196c3e74ce9184fL76-R77)
  * `humitifier-common/src/humitifier_common/artefacts/special.py`

### Typed Dictionaries for Artefacts:
* [`humitifier-common/src/humitifier_common/scan_data.py`](diffhunk://#diff-a4ee65f7cf2cc5495288dcc894c226be9353dda182eb2569ae4f4c2878765b16R133-R136): Introduced `FactTypedDict` and `MetricTypedDict` to replace generic dictionaries for facts and metrics, improving type safety. [[1]](diffhunk://#diff-a4ee65f7cf2cc5495288dcc894c226be9353dda182eb2569ae4f4c2878765b16R133-R136) [[2]](diffhunk://#diff-a4ee65f7cf2cc5495288dcc894c226be9353dda182eb2569ae4f4c2878765b16L161-L237)
* Removed the `_parse_artefact` method from `ScanOutput` as it is no longer needed with typed dictionaries.

### Utility Functions:
* [`humitifier-common/src/humitifier_common/utils/pydantic.py`](diffhunk://#diff-a494dc408e8f1fd418e0a6a92b02588db3cd14942bbfedaa906f46b7028f01a1R1-R87): Added utility functions `create_typed_dict` and `insert_pydantic_schema_proxy` to support dynamic typed dictionary creation and pydantic schema compatibility.

### Registry Enhancements:
* [`humitifier-common/src/humitifier_common/artefacts/registry/registry.py`](diffhunk://#diff-2b95449fc3a991a1617cde3f0a4a0063db10cc2e9eb83bccfffa5a580148b049R9-R10): Integrated `insert_pydantic_schema_proxy` into the `fact` and `metric` decorators to ensure artefact classes are compatible with pydantic's schema generation. [[1]](diffhunk://#diff-2b95449fc3a991a1617cde3f0a4a0063db10cc2e9eb83bccfffa5a580148b049R9-R10) [[2]](diffhunk://#diff-2b95449fc3a991a1617cde3f0a4a0063db10cc2e9eb83bccfffa5a580148b049R335-R336) [[3]](diffhunk://#diff-2b95449fc3a991a1617cde3f0a4a0063db10cc2e9eb83bccfffa5a580148b049R374-R375)