### PR TITLE
fix: add localhost check for host online validation

### DIFF
--- a/humitifier-common/pyproject.toml
+++ b/humitifier-common/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humitifier-common"
-version = "4.5.1"
+version = "4.5.3"
 description = ""
 authors = ["Mees, T.D. (Ty) <t.d.mees@uu.nl>"]
 readme = "README.md"

--- a/humitifier-scanner/pyproject.toml
+++ b/humitifier-scanner/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "humitifier-scanner"
-version = "4.5.1"
+version = "4.5.3"
 description = ""
 authors = ["Mees, T.D. (Ty) <t.d.mees@uu.nl>"]
 readme = "README.md"

--- a/humitifier-scanner/src/humitifier_scanner/constants.py
+++ b/humitifier-scanner/src/humitifier_scanner/constants.py
@@ -1,4 +1,4 @@
-HUMITIFIER_VERSION = "4.5.1"
+HUMITIFIER_VERSION = "4.5.3"
 
 DEB_OS_LIST = ["debian", "ubuntu"]
 RPM_OS_LIST = ["redhat", "red hat", "centos", "fedora", "almalinux"]

--- a/humitifier-scanner/src/humitifier_scanner/scanner.py
+++ b/humitifier-scanner/src/humitifier_scanner/scanner.py
@@ -19,6 +19,7 @@ from humitifier_common.scan_data import (
     ScanInput,
     ScanOutput,
 )
+from humitifier_scanner.utils import get_local_fqdn
 
 
 def scan(input_data: ScanInput) -> ScanOutput:
@@ -180,6 +181,10 @@ def resolve_collector_order(collectors, dependencies):
 
 
 def _check_host_online(hostname):
+    # Localhost is always online, by definition
+    if _check_host_is_localhost(hostname):
+        return True
+
     # Why are we building in support for Windows? Reasons!
     ping_count_arg = "-n" if sys.platform.lower() == "win32" else "-c"
 
@@ -201,6 +206,11 @@ def _check_host_online(hostname):
     except Exception as e:
         logger.error(f"An error occurred while trying to contact host {hostname}: {e}")
         return False
+
+def _check_host_is_localhost(hostname):
+    localhost = get_local_fqdn()
+
+    return localhost == hostname
 
 
 def _run_collector(

--- a/humitifier-scanner/src/humitifier_scanner/scanner.py
+++ b/humitifier-scanner/src/humitifier_scanner/scanner.py
@@ -207,6 +207,7 @@ def _check_host_online(hostname):
         logger.error(f"An error occurred while trying to contact host {hostname}: {e}")
         return False
 
+
 def _check_host_is_localhost(hostname):
     localhost = get_local_fqdn()
 

--- a/humitifier-server/pyproject.toml
+++ b/humitifier-server/pyproject.toml
@@ -5,7 +5,7 @@ target-version = [
 
 [tool.poetry]
 name = "humitifier-server"
-version = "4.5.1"
+version = "4.5.3"
 description = ""
 authors = [
     "Mees, T.D. (Ty) <t.d.mees@uu.nl>",


### PR DESCRIPTION
Added a function to verify if a hostname corresponds to the localhost. Updated the `_check_host_online` function to return true for localhost without further checks. Imported `get_local_fqdn` utility to support this functionality.