### PR TITLE
feat: add Systemd artefact, collector, visualizer, and alerts

### DIFF
--- a/humitifier-common/src/humitifier_common/artefacts/generic.py
+++ b/humitifier-common/src/humitifier_common/artefacts/generic.py
@@ -168,3 +168,18 @@ class SELinux(BaseModel):
     enabled: bool
     policy_name: str | None
     mode: str | None
+
+##
+## SystemD info
+##
+
+class SystemdUnit(BaseModel):
+    unit: str
+    load: str
+    description: str | None
+    active: str
+    sub: str
+
+@fact(group=GENERIC, metadata=ArtefactMetadata(null_is_valid=True))
+class Systemd(BaseModel):
+    units: list[SystemdUnit]

--- a/humitifier-scanner/src/humitifier_scanner/collectors/generic.py
+++ b/humitifier-scanner/src/humitifier_scanner/collectors/generic.py
@@ -19,6 +19,8 @@ from humitifier_common.artefacts import (
     Package,
     PackageList,
     SELinux,
+    Systemd,
+    SystemdUnit,
     User,
     Users,
 )
@@ -427,3 +429,36 @@ class SELinuxFactCollector(ShellCollector):
             policy_name=policy_name,
             mode=mode,
         )
+
+
+class SystemDFactCollector(ShellCollector):
+    fact = Systemd
+    required_facts = [HostnameCtl]
+
+    def collect_from_shell(
+        self, shell_executor: LinuxShellExecutor, info: CollectInfo
+    ) -> Systemd | None:
+
+        # CentOS 7 and Debian 10 are not compatible with this code, as it lacks
+        # the -o flag
+        # And I really cannot be bothered to write compatible code,
+        # as it's hard to parse and those OS's should be phased out anyway.
+        host_info: HostnameCtl = info.required_facts[HostnameCtl]
+        if (host_info.cpe_os_name == "cpe:/o:centos:centos:7"
+            or host_info.os == "Debian GNU/Linux 10 (buster)"):
+            return None
+
+        result = shell_executor.execute("systemctl list-units --output json")
+
+        try:
+            unit_data = json.loads("".join(result.stdout))
+        except json.JSONDecodeError:
+            self.add_error("Failed to parse systemctl output")
+            return None
+
+        units = []
+
+        for datum in unit_data:
+            units.append(SystemdUnit(**datum))
+
+        return Systemd(units=units)

--- a/humitifier-server/src/alerting/alerts/generic.py
+++ b/humitifier-server/src/alerting/alerts/generic.py
@@ -231,3 +231,25 @@ class SELinuxAlertGenerator(BaseArtefactAlertGenerator):
             )
 
         return alerts
+
+
+class SystemdAlertGenerator(BaseArtefactAlertGenerator):
+    artefact = Systemd
+    verbose_name = "Systemd state"
+
+    def generate_alerts(self) -> AlertData | list[AlertData] | None:
+        if not self.artefact_data:
+            return None
+
+        data: Systemd = self.artefact_data
+        alerts = []
+
+        for unit in data.units:
+            if unit.active == "failed":
+                alerts.append(AlertData(
+                    severity=AlertSeverity.WARNING,
+                    message=f"Systemd: {unit.unit} is in a failed state",
+                    custom_identifier=f"failed-unit-{unit.unit}",
+                ))
+
+        return alerts

--- a/humitifier-server/src/hosts/scan_visualizers/v2/artefact_visualizers.py
+++ b/humitifier-server/src/hosts/scan_visualizers/v2/artefact_visualizers.py
@@ -39,6 +39,7 @@ from humitifier_common.artefacts import (
     Webhost,
     Webserver,
     ZFS,
+    Systemd,
 )
 
 
@@ -507,3 +508,28 @@ class SELinuxVisualizer(ItemizedArtefactVisualizer):
             </div>
             """
         )
+
+
+class SystemdUnitsVisualizer(SearchableCardsVisualizer):
+    artefact = Systemd
+    title = "Systemd Units"
+
+    def get_items(self) -> list[Card]:
+        items = []
+
+        for unit in self.artefact_data.units:
+            items.append(
+                Card(
+                    title=unit.unit,
+                    aside=unit.active,
+                    content_items={
+                        "Description": unit.description,
+                        "Sub state": unit.sub,
+                        "Loaded": unit.load,
+                    },
+                    search_value=f"{unit.unit} {unit.description} {unit.active}",
+                )
+            )
+
+        return items
+

--- a/humitifier-server/src/hosts/scan_visualizers/v2/scan_visualizer.py
+++ b/humitifier-server/src/hosts/scan_visualizers/v2/scan_visualizer.py
@@ -27,6 +27,7 @@ class V2ScanVisualizer(ComponentScanVisualizer):
         visualizers.PackageListVisualizer,
         visualizers.UsersVisualizer,
         visualizers.GroupsVisualizer,
+        visualizers.SystemdUnitsVisualizer,
     ]
 
     static_data = {


### PR DESCRIPTION
Introduced the `Systemd` artefact to capture details about systemd units. Implemented the `SystemDFactCollector` for collecting relevant data via `systemctl`. Added a visualizer for displaying systemd unit states and an alert generator to warn about failed units.